### PR TITLE
Fix a bug with normalization

### DIFF
--- a/R/fct_dea.R
+++ b/R/fct_dea.R
@@ -48,8 +48,8 @@ estimateDispersion <- function(tcc, conditions = NULL) {
 
   dge <- edgeR::DGEList(
     counts = tcc$count,
-    lib.size = tcc$norm.factors,
-    norm.factors = colSums(tcc$count),
+    lib.size = colSums(tcc$count),
+    norm.factors = tcc$norm.factors,
     group = groups,
     genes = rownames(tcc$count)
   )

--- a/inst/extdata/NEWS.md
+++ b/inst/extdata/NEWS.md
@@ -59,3 +59,7 @@ Bug fixes :
 + Fixed not displaying go results for custom org in network communities
 
 + In draw expression levels, genes filtered because of low expression can still be viewed
+
+### January 8, 2024 - Fix
+
+Fix a bug with normalization : Normalization was using total count instead of the normalization factors computed by the chosen method.


### PR DESCRIPTION
Small fix for a bug with normalization. 

Normalization was using total count instead of the normalization factors computed by the chosen method.